### PR TITLE
Feature/run proteomics results only and other adjustments

### DIFF
--- a/R/proteomics_plots.R
+++ b/R/proteomics_plots.R
@@ -30,6 +30,13 @@ proteomics_plots_rii <- function(all_vial_labels,
                              
   if(verbose) message("   + (+) PLOTS RII------------------")
   
+  # Get the total number of samples to customize the plots. If larger than 200, 
+  # prepare for large plots
+  sn <- length(unique(all_samples))
+  # Set a limit for which remove labels 
+  sn_limit <- 200
+  
+  
   if( !is.null(all_vial_labels) ){
     required_columns <- get_required_columns(isPTM = isPTM,
                                              prot_file = "rii")
@@ -156,7 +163,15 @@ proteomics_plots_rii <- function(all_vial_labels,
         out_plot_dist <- file.path(normalizePath(out_qc_folder), paste0(output_prefix,"-qc-rii-distribution.pdf"))
       }
       
-      if(printPDF) pdf(out_plot_dist, width = 12, height = 8)
+      if(printPDF){
+        if(sn > 800){
+          pdf(out_plot_dist, width = 40, height = 8)
+        }else if(sn <= 800 & sn > 200){
+          pdf(out_plot_dist, width = 22, height = 8)
+        }else{
+          pdf(out_plot_dist, width = 14, height = 8)
+        }
+      }
       print(pise)
       print(puid1)
       print(puid2)

--- a/R/validations.R
+++ b/R/validations.R
@@ -81,8 +81,8 @@ set_phase <- function(input_results_folder,
   
   # Check metadata_phase.txt file
   batch <- NULL
-  if( grepl("RESULTS", input_results_folder) ){
-    batch <- gsub("(.*)(RESULTS.*)", "\\1", input_results_folder)  
+  if( grepl("(BIC){0,1}RESULTS", input_results_folder) ){
+    batch <- gsub("(.*/)((BIC){0,1}RESULTS.*)", "\\1", input_results_folder)  
   }else if( grepl("PROCESSED", input_results_folder)){
     batch <- gsub("(.*)(PROCESSED.*)", "\\1", input_results_folder)  
   }else{
@@ -273,7 +273,7 @@ validate_processFolder <- function(input_results_folder){
   processfolder <- stringr::str_extract(string = input_results_folder, pattern = "PROCESSED_[0-9]+")
 
   if(is.na(processfolder)){
-    processfolder <- stringr::str_extract(string = input_results_folder, pattern = "RESULTS_[0-9]+")
+    processfolder <- stringr::str_extract(string = input_results_folder, pattern = "(BIC){0,1}RESULTS_[0-9]+")
   }
 
   if(is.na(processfolder)){

--- a/man/validate_proteomics.Rd
+++ b/man/validate_proteomics.Rd
@@ -16,7 +16,7 @@ validate_proteomics(
   full_report = FALSE,
   printPDF = TRUE,
   verbose = TRUE,
-  run_by_bic = FALSE
+  check_only_results = FALSE
 )
 }
 \arguments{
@@ -26,7 +26,8 @@ validate_proteomics(
 
 \item{cas}{(char) CAS code}
 
-\item{dmaqc_shipping_info}{(char) phase code}
+\item{dmaqc_shipping_info}{(char) DMAQC file with shipping information. If not provided
+(default), then DMQAC validation is not peformed (only done at the BIC)}
 
 \item{dmaqc_phase2validate}{(char) Provide phase to validate. This argument
 is not required since it should be extracted from the input folder or from the
@@ -57,8 +58,7 @@ group of files, e.g., results, metadata_metabolites, etc)}
 
 \item{verbose}{(logical) \code{TRUE} (default) prints QC details.}
 
-\item{run_by_bic}{(logical) \code{TRUE} if the dataset was generated running the
-BIC proteomics pipeline (default \code{FALSE})}
+\item{check_only_results}{(logical) if \code{TRUE}, only validates results (default \code{FALSE})}
 }
 \value{
 (data.frame) Summary of issues

--- a/tests/testthat/test-validations.R
+++ b/tests/testthat/test-validations.R
@@ -5,12 +5,20 @@ test_that("All validations works", {
   y <- "MORESTUFF/PASS1A-06/T31/IONPNEG/BATCH1_20190909/PROCESSED_20200205/EVENMOREFOLDERS/"
   z <- "PASS1B-06/T100/IONPNEG/BATCH1_20190909/PROCESSED_20200205"
   b <- "PASS1A-06/T31/IONPNEG/BATCH1_2019090990/PROCESSED_20200205"
+  h <- "HUMAN/T10/IONPNEG/BATCH1_20190909/RESULTS_20220101"
+  j <- "HUMAN/T10/IONPNEG/BATCH1_20190909/BICRESULTS_20220101"
+  k <- "HUMAN/T10/IONPNEG/BATCH1_20190909/TOPRESULTS_20220101"
   expect_equal(validate_processFolder(x), "PROCESSED_20200205")
   expect_equal(validate_processFolder(y), "PROCESSED_20200205")
   expect_equal(validate_assay(x), "IONPNEG")
   expect_equal(validate_phase(x), "PASS1A-06")
   expect_equal(validate_phase(y), "PASS1A-06")
   expect_equal(validate_tissue(x), "T31")
+  expect_equal(validate_batch(h), "HUMAN/T10/IONPNEG/BATCH1_20190909/")
+  expect_equal(validate_batch(j), "HUMAN/T10/IONPNEG/BATCH1_20190909/")
+  expect_equal(validate_processFolder(h), "RESULTS_20220101")
+  expect_equal(validate_processFolder(j), "BICRESULTS_20220101")
+  expect_no_match(validate_processFolder(k), "TOPRESULTS_20220101")
   expect_error(validate_tissue(z))
   expect_equal(validate_batch(x), "PASS1A-06/T31/IONPNEG/BATCH1_20190909/")
   expect_error(validate_batch(b))

--- a/tests/testthat/test-validations.R
+++ b/tests/testthat/test-validations.R
@@ -18,7 +18,7 @@ test_that("All validations works", {
   expect_equal(validate_batch(j), "HUMAN/T10/IONPNEG/BATCH1_20190909/")
   expect_equal(validate_processFolder(h), "RESULTS_20220101")
   expect_equal(validate_processFolder(j), "BICRESULTS_20220101")
-  expect_no_match(validate_processFolder(k), "TOPRESULTS_20220101")
+  expect_error(expect_match(validate_processFolder(k), "TOPRESULTS_20220101"))
   expect_error(validate_tissue(z))
   expect_equal(validate_batch(x), "PASS1A-06/T31/IONPNEG/BATCH1_20190909/")
   expect_error(validate_batch(b))


### PR DESCRIPTION
Updates affecting the proteomics validation:
- `validate_proteomics`: rename and adjust `run_by_bic` to `check_only_results`. Default is still `FALSE`, therefore it does not affect CAS
- Adjust size of pdf depending on the number of samples
- Support `BICRESULTS` folder (in addition to the similar `RESULTS` and `PROCESSED` folder)
