### PR TITLE
v0.8.8: 24 hours time support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: MotrpacBicQC
 Type: Package
 Title: QC/QA functions for the MoTrPAC community
-Version: 0.8.7
-Date: 2023-05-22
+Version: 0.8.8
+Date: 2023-06-15
 Author: MoTrPAC Bioinformatics Center
 Maintainer: David Jimenez-Morales <davidjm@stanford.edu>
 Description: R Package for the analysis of MoTrPAC datasets. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# MotrpacBicQC 0.8.8 (2023-06-15)
+
+* Add 24 hours time support for the `acquisition_date` (`MM/DD/YYYY HH:MM:SS`)
+
 # MotrpacBicQC 0.8.7 (2023-05-22)
 
 * Add QC for the new required batching variables

--- a/R/misc.R
+++ b/R/misc.R
@@ -136,7 +136,7 @@ dl_read_gcp <- function(path,
     dt <- data.table::fread(new_path, sep=sep, header=header,...)
     return(dt)
   }else{
-    stop("- Problems loading the file")
+    stop("- Problems loading the file. Possible reason: the file does not exist in the bucket anymore. Please, validate the address. Re-run this command again with `verbose = TRUE`)")
   }
 }
 

--- a/R/validations.R
+++ b/R/validations.R
@@ -311,8 +311,10 @@ validate_dates_times <- function(df, column_name, verbose = TRUE) {
   parsed_datetimes <- lubridate::parse_date_time(datetime_values, 
                                                  orders = c("mdy HM", 
                                                             "mdy HMp", 
+                                                            "mdy H:M:S",
                                                             "m/d/y h:M:s a", 
-                                                            "m/d/y h:M a"), 
+                                                            "m/d/y h:M a",
+                                                            "mdY h:M:S p"), 
                                                  quiet = TRUE)
   
   # Detect incorrect format

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/articles/other_functions.html
+++ b/docs/articles/other_functions.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="generator" content="pandoc">
-<meta name="date" content="2023-05-22">
+<meta name="date" content="2023-06-15">
 <title>MotrpacBicQC: Other Functions</title>
 <script src="other_functions_files/header-attrs-2.21/header-attrs.js"></script><script src="other_functions_files/jquery-3.6.0/jquery-3.6.0.min.js"></script><meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="other_functions_files/bootstrap-3.3.7/css/bootstrap.min.css" rel="stylesheet">
@@ -123,7 +123,7 @@
       
       <p class="authors">
          </p>
-<p class="date"><span class="glyphicon glyphicon-calendar"></span> 2023-05-22</p>
+<p class="date"><span class="glyphicon glyphicon-calendar"></span> 2023-06-15</p>
            
 
    

--- a/docs/articles/qc_metabolomics.html
+++ b/docs/articles/qc_metabolomics.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="generator" content="pandoc">
-<meta name="date" content="2023-05-22">
+<meta name="date" content="2023-06-15">
 <title>MotrpacBicQC: Metabolomics QC</title>
 <script src="qc_metabolomics_files/header-attrs-2.21/header-attrs.js"></script><script src="qc_metabolomics_files/jquery-3.6.0/jquery-3.6.0.min.js"></script><meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="qc_metabolomics_files/bootstrap-3.3.7/css/bootstrap.min.css" rel="stylesheet">
@@ -126,7 +126,7 @@
       
       <p class="authors">
          </p>
-<p class="date"><span class="glyphicon glyphicon-calendar"></span> 2023-05-22</p>
+<p class="date"><span class="glyphicon glyphicon-calendar"></span> 2023-06-15</p>
            
 
    

--- a/docs/articles/qc_proteomics.html
+++ b/docs/articles/qc_proteomics.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="generator" content="pandoc">
-<meta name="date" content="2023-05-22">
+<meta name="date" content="2023-06-15">
 <title>MotrpacBicQC: Proteomics QC</title>
 <script src="qc_proteomics_files/header-attrs-2.21/header-attrs.js"></script><script src="qc_proteomics_files/jquery-3.6.0/jquery-3.6.0.min.js"></script><meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="qc_proteomics_files/bootstrap-3.3.7/css/bootstrap.min.css" rel="stylesheet">
@@ -125,7 +125,7 @@
       
       <p class="authors">
          </p>
-<p class="date"><span class="glyphicon glyphicon-calendar"></span> 2023-05-22</p>
+<p class="date"><span class="glyphicon glyphicon-calendar"></span> 2023-06-15</p>
            
 
    

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 
@@ -79,13 +79,13 @@
 
     <p>Center MB (2023).
 <em>MotrpacBicQC: QC/QA functions for the MoTrPAC community</em>.
-R package version 0.8.7, <a href="https://github.com/MoTrPAC/MotrpacBicQC" class="external-link">https://github.com/MoTrPAC/MotrpacBicQC</a>. 
+R package version 0.8.8, <a href="https://github.com/MoTrPAC/MotrpacBicQC" class="external-link">https://github.com/MoTrPAC/MotrpacBicQC</a>. 
 </p>
     <pre>@Manual{,
   title = {MotrpacBicQC: QC/QA functions for the MoTrPAC community},
   author = {MoTrPAC Bioinformatics Center},
   year = {2023},
-  note = {R package version 0.8.7},
+  note = {R package version 0.8.8},
   url = {https://github.com/MoTrPAC/MotrpacBicQC},
 }</pre>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 
@@ -63,6 +63,10 @@
       <small>Source: <a href="https://github.com/MoTrPAC/MotrpacBicQC/blob/HEAD/NEWS.md" class="external-link"><code>NEWS.md</code></a></small>
     </div>
 
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="0.8.8" id="motrpacbicqc-088-2023-06-15">MotrpacBicQC 0.8.8 (2023-06-15)<a class="anchor" aria-label="anchor" href="#motrpacbicqc-088-2023-06-15"></a></h2>
+<ul><li>Add 24 hours time support for the <code>acquisition_date</code> (<code>MM/DD/YYYY HH:MM:SS</code>)</li>
+</ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.8.7" id="motrpacbicqc-087-2023-05-22">MotrpacBicQC 0.8.7 (2023-05-22)<a class="anchor" aria-label="anchor" href="#motrpacbicqc-087-2023-05-22"></a></h2>
 <ul><li>Add QC for the new required batching variables</li>

--- a/docs/notes_developers.html
+++ b/docs/notes_developers.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,9 +1,9 @@
-pandoc: 2.19.2
+pandoc: 3.1.1
 pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   other_functions: other_functions.html
   qc_metabolomics: qc_metabolomics.html
   qc_proteomics: qc_proteomics.html
-last_built: 2023-05-22T16:25Z
+last_built: 2023-06-15T22:43Z
 

--- a/docs/reference/assay_abbr.html
+++ b/docs/reference/assay_abbr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/assay_codes.html
+++ b/docs/reference/assay_codes.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/assay_order.html
+++ b/docs/reference/assay_order.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/bic_animal_tissue_code.html
+++ b/docs/reference/bic_animal_tissue_code.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_failedsamples.html
+++ b/docs/reference/check_failedsamples.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_manifest_rawdata.html
+++ b/docs/reference/check_manifest_rawdata.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_metadata_metabolites.html
+++ b/docs/reference/check_metadata_metabolites.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 
@@ -111,11 +111,8 @@
 <span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) `metabolite_name` OK</span>
 <span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) `refmet_name` unique values: OK</span>
 <span class="r-msg co"><span class="r-pr">#&gt;</span>   + Validating `refmet_name` (it might take some time)</span>
-<span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) `refmet_name` ids found in refmet: OK</span>
-<span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) {rt} all numeric: OK</span>
-<span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) {mz} all numeric: OK</span>
-<span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) {`neutral_mass`} all numeric values OK</span>
-<span class="r-msg co"><span class="r-pr">#&gt;</span>   + (+) {formula} available: OK</span>
+<span class="r-wrn co"><span class="r-pr">#&gt;</span> <span class="warning">Warning: </span>URL 'https://www.metabolomicsworkbench.org/rest/refmet/match/Isoleucine/name/': status was 'Server returned nothing (no headers, no data)'</span>
+<span class="r-err co"><span class="r-pr">#&gt;</span> <span class="error">Error in open.connection(con, "rb"):</span> cannot open the connection to 'https://www.metabolomicsworkbench.org/rest/refmet/match/Isoleucine/name/'</span>
 </code></pre></div>
     </div>
   </div>

--- a/docs/reference/check_metadata_phase_file.html
+++ b/docs/reference/check_metadata_phase_file.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_metadata_samples.html
+++ b/docs/reference/check_metadata_samples.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_ratio_proteomics.html
+++ b/docs/reference/check_ratio_proteomics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_results.html
+++ b/docs/reference/check_results.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_rii_proteomics.html
+++ b/docs/reference/check_rii_proteomics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_vial_metadata_proteomics.html
+++ b/docs/reference/check_vial_metadata_proteomics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/check_viallabel_dmaqc.html
+++ b/docs/reference/check_viallabel_dmaqc.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/combine_metabolomics_batch.html
+++ b/docs/reference/combine_metabolomics_batch.html
@@ -19,7 +19,7 @@ folders'><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mat
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/create_folder.html
+++ b/docs/reference/create_folder.html
@@ -18,7 +18,7 @@ it returns the current working directory"><!-- mathjax --><script src="https://c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/dl_read_gcp.html
+++ b/docs/reference/dl_read_gcp.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 
@@ -90,7 +90,7 @@
 
 
 <dt>sep</dt>
-<dd><p>(char) column separator to use with <a href="https://Rdatatable.gitlab.io/data.table/reference/fread.html" class="external-link">data.table::fread</a></p></dd>
+<dd><p>(char) column separator to use with <a href="https://rdrr.io/pkg/data.table/man/fread.html" class="external-link">data.table::fread</a></p></dd>
 
 
 <dt>header</dt>
@@ -125,7 +125,7 @@ Should be set to <code>TRUE</code> if you are running this function in parallel.
 
 
 <dt>...</dt>
-<dd><p>optional arguments for <a href="https://Rdatatable.gitlab.io/data.table/reference/fread.html" class="external-link">data.table::fread</a></p></dd>
+<dd><p>optional arguments for <a href="https://rdrr.io/pkg/data.table/man/fread.html" class="external-link">data.table::fread</a></p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/filter_required_columns.html
+++ b/docs/reference/filter_required_columns.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/generate_phase_details.html
+++ b/docs/reference/generate_phase_details.html
@@ -21,7 +21,7 @@ generate the expected version: either pass1ac-06 or pass1ac-18"><!-- mathjax -->
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/get_and_validate_mdd.html
+++ b/docs/reference/get_and_validate_mdd.html
@@ -18,7 +18,7 @@ Metabolomics Workbench"><!-- mathjax --><script src="https://cdnjs.cloudflare.co
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/get_full_path2batch.html
+++ b/docs/reference/get_full_path2batch.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/group_abbr.html
+++ b/docs/reference/group_abbr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/group_cols.html
+++ b/docs/reference/group_cols.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/load_metabolomics_batch.html
+++ b/docs/reference/load_metabolomics_batch.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/load_proteomics.html
+++ b/docs/reference/load_proteomics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/merge_all_metabolomics.html
+++ b/docs/reference/merge_all_metabolomics.html
@@ -18,7 +18,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/merge_metabolomics_metadata.html
+++ b/docs/reference/merge_metabolomics_metadata.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/merge_phenotype_metabolomics.html
+++ b/docs/reference/merge_phenotype_metabolomics.html
@@ -18,7 +18,7 @@ metabolomics merged results and metadata"><!-- mathjax --><script src="https://c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/metabolomics_data_dictionary.html
+++ b/docs/reference/metabolomics_data_dictionary.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/metadata_metabolites_named.html
+++ b/docs/reference/metadata_metabolites_named.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/metadata_metabolites_unnamed.html
+++ b/docs/reference/metadata_metabolites_unnamed.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/metadata_sample_named.html
+++ b/docs/reference/metadata_sample_named.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/metadata_sample_unnamed.html
+++ b/docs/reference/metadata_sample_unnamed.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/open_file.html
+++ b/docs/reference/open_file.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/phenotypes_pass1a06_short.html
+++ b/docs/reference/phenotypes_pass1a06_short.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/plot_basic_metabolomics_qc.html
+++ b/docs/reference/plot_basic_metabolomics_qc.html
@@ -18,7 +18,7 @@ and RT/MZ density maps (only untargeted)"><!-- mathjax --><script src="https://c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/proteomics_plots_rii.html
+++ b/docs/reference/proteomics_plots_rii.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/remove_empty_columns.html
+++ b/docs/reference/remove_empty_columns.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/remove_empty_rows.html
+++ b/docs/reference/remove_empty_rows.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/results_named.html
+++ b/docs/reference/results_named.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/results_unnamed.html
+++ b/docs/reference/results_unnamed.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/set_phase.html
+++ b/docs/reference/set_phase.html
@@ -27,7 +27,7 @@ Phase in folder structure
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/sex_abbr.html
+++ b/docs/reference/sex_abbr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/sex_cols.html
+++ b/docs/reference/sex_cols.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/tissue_abbr.html
+++ b/docs/reference/tissue_abbr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/tissue_cols.html
+++ b/docs/reference/tissue_cols.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/tissue_order.html
+++ b/docs/reference/tissue_order.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_assay.html
+++ b/docs/reference/validate_assay.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_batch.html
+++ b/docs/reference/validate_batch.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_cas.html
+++ b/docs/reference/validate_cas.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_dates_times.html
+++ b/docs/reference/validate_dates_times.html
@@ -19,7 +19,7 @@ with this format, it prints out those values.'><!-- mathjax --><script src="http
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 
@@ -105,7 +105,7 @@ with this format, it prints out those values.</p>
 <span class="r-in"><span>                               <span class="st">"02/29/2024 12:00:00 PM"</span>, <span class="st">"13/01/2024 01:00:00 PM"</span>, </span></span>
 <span class="r-in"><span>                               <span class="st">"02/28/2024 24:00:00 PM"</span>, <span class="st">"02/30/2024 12:00:00 PM"</span><span class="op">)</span><span class="op">)</span></span></span>
 <span class="r-in"><span><span class="fu">validate_dates_times</span><span class="op">(</span><span class="va">df</span>, <span class="st">"datetime"</span>, <span class="cn">TRUE</span><span class="op">)</span></span></span>
-<span class="r-msg co"><span class="r-pr">#&gt;</span>    - (-)`datetime`: Values in incorrect format: `12/31/2023 11:59:59 PM, 01/01/2024 00:00:00 AM, 02/29/2024 12:00:00 PM, 13/01/2024 01:00:00 PM, 02/28/2024 24:00:00 PM, 02/30/2024 12:00:00 PM`</span>
+<span class="r-msg co"><span class="r-pr">#&gt;</span>    - (-)`datetime`: Values in incorrect format: `13/01/2024 01:00:00 PM, 02/30/2024 12:00:00 PM`</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> [1] 1</span>
 <span class="r-in"><span></span></span>
 </code></pre></div>

--- a/docs/reference/validate_lc_column_id.html
+++ b/docs/reference/validate_lc_column_id.html
@@ -19,7 +19,7 @@ in its entries. It also reports the number of unique values in the column."><!--
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_metabolomics.html
+++ b/docs/reference/validate_metabolomics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_na_empty.html
+++ b/docs/reference/validate_na_empty.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_phase.html
+++ b/docs/reference/validate_phase.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_processFolder.html
+++ b/docs/reference/validate_processFolder.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_proteomics.html
+++ b/docs/reference/validate_proteomics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_refmetname.html
+++ b/docs/reference/validate_refmetname.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_tissue.html
+++ b/docs/reference/validate_tissue.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_two_phases.html
+++ b/docs/reference/validate_two_phases.html
@@ -18,7 +18,7 @@ as for example, 'PASS1A-06|PASS1C-06' using the separator '|'"><!-- mathjax --><
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/validate_yyyymmdd_dates.html
+++ b/docs/reference/validate_yyyymmdd_dates.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/write_metabolomics_releases.html
+++ b/docs/reference/write_metabolomics_releases.html
@@ -18,7 +18,7 @@ data has been submited according to guidelines"><!-- mathjax --><script src="htt
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 

--- a/docs/reference/write_proteomics_releases.html
+++ b/docs/reference/write_proteomics_releases.html
@@ -18,7 +18,7 @@ data has been submited according to guidelines"><!-- mathjax --><script src="htt
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">MotrpacBicQC</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.7</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.8</span>
       </span>
     </div>
 


### PR DESCRIPTION
* Add 24 hours time support for the `acquisition_date` (`MM/DD/YYYY HH:MM:SS`)

#206 
#205 